### PR TITLE
Improve Dockerfile and image-push action

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -6,45 +6,36 @@
 
 name: Create and publish the APSVIZ k8s Supervisor Docker image tagged with "latest" and version number
 
-# trigger event is publishing the repo
+# trigger event is publishing a release in the repo
 on:
   release:
     types: [published]
 
 # working parameters that are specific to this script
 env:
-  REGISTRY: containers.renci.org/eds
-  NAME: apsviz-supervisor
-  USER: ${{ secrets.USER }}
-  PW: ${{ secrets.PW }}
+  REGISTRY: containers.renci.org/eds/apsviz-supervisor
 
 # job definition
 jobs:
-  # job definition
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     # job steps
     steps:
-      # pull in the code repo
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      # get the tags for the image
-      - name: Get the version
-        id: get_version
-        run: |
-          echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      # build and push the image
-      - name: Build/Push the image to the registry
-        uses: docker/build-push-action@v1
+      - name: Login to containers.renci.org
+        uses: docker/login-action@v2
         with:
-          repository: ${{ env.NAME }}
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.USER }}
-          password: ${{ env.PW }}
-          tags: latest,${{ steps.get_version.outputs.VERSION }}
+          registry: containers.renci.org
+          username: ${{ secrets.USER }}
+          password: ${{ secrets.PW }}
+
+      # build and push the image. The docker v3 action automatically handles the git checkout.
+      - name: Build/Push the image to the registry
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}:latest
+            ${{ env.REGISTRY }}:${{ env.GITHUB_REF_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,45 +6,26 @@
 
 # This Dockerfile is used to build the APSVIZ-Supervisor image
 # starts with the python image
-# installs nano
 # creates a directory for the repo
-# gets the APSVIZ-Supervisor repo
+# copies in the APSVIZ-Supervisor repo
 # and runs main which enables the supervisor
 
 # leverage the renci python base image
-FROM renciorg/renci-python-image:v0.0.1
+FROM python:3.9-slim
 
-# create log level env param (debug=10, info=20)
-ENV LOG_LEVEL 20
+# create a new non-root user and switch to it
+RUN useradd --create-home -u 1000 nru
+USER nru
 
-# make a directory for the repo
-RUN mkdir /repo
-
-# go to the directory where we are going to upload the repo
-WORKDIR /repo
-
-# get the latest code
-RUN git clone https://github.com/RENCI/APSVIZ-Supervisor.git
-
-# go to the repo dir
+# Create the directory for the code and cd to it
 WORKDIR /repo/APSVIZ-Supervisor
 
-# make sure everything is read/write in the repo code
-RUN chmod 777 -R .
-
-# install all required packages
+# Copy in just the requirements first for caching purposes
+COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-# debug only - copy in test supervisor code. other wise the repo code is fine
-#COPY ./supervisor/src/job_supervisor.py /repo/APSVIZ-Supervisor/supervisor/src/job_supervisor.py
-#COPY ./supervisor/src/job_create.py /repo/APSVIZ-Supervisor/supervisor/src/job_create.py
-#COPY ./postgres/src/pg_utils.py /repo/APSVIZ-Supervisor/postgres/src/pg_utils.py
-
-# install requirements
-RUN pip install -r requirements.txt
-
-# switch to the non-root user (nru). defined in the base image
-USER nru
+# Copy in the rest of the code
+COPY . .
 
 # start the service entry point
 ENTRYPOINT ["python", "main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@
 # SPDX-License-Identifier: MIT
 
 kubernetes==22.6.0
-psycopg2==2.9.3
+psycopg2-binary==2.9.3
 slack-sdk==3.18.1


### PR DESCRIPTION
I made the majority of these changes incidentally while testing that networking issue, so I figured I should package this all up into a PR :)

Explanations of each change in the order they appear in the diff:

Action:
* Removed unnecessary "packages: write" permission in the github action. I think that's for pushing to the github container registry
* Removed the shell command to fetch the tag name; that can be obtained with `env.GITHUB_REF_NAME`: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
* Migrated to build-push-action@v3

Dockerfile:
* Removed the use of that base image. A base image needs a team of people who are constantly patching it, but that base image is 8 months old and has more than 3,000 CVEs in it!
    - Using the upstream python base image gives us those regular updates, and the `slim` version reduces the image size from 350MB to 60MB!
* Actually create the home folder for `nru`. Without a home folder, pip crashes when the install is run as `nru`. 
   - Performing the build steps as `nru` means we don't need to worry about permissions. It also means we can remove the spooky "chmod 777".
* Installed requirements.txt before copying in the code. This makes local development nicer since the pip install step doesn't re-execute every time you change a file. It only re-executes if you change requirements.txt.
* Replaced the git clone step with a COPY. The git repo cloning is handled automatically by the docker build-push-action.

requirements.txt:
* Installed the binary version of psycopg. This means you don't have to compile the thing from source anymore, saving lots of time (only takes 8 seconds now!). The binary version is also needed because the `slim` image doesn't include compilation tools.